### PR TITLE
IOS-294 Initial iteration with SPM and Xcode project support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Finder bs
+.DS_Store
+
 ## User settings
 xcuserdata/
 
@@ -11,6 +14,7 @@ xcuserdata/
 
 ## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
 build/
+Build
 DerivedData/
 *.moved-aside
 *.pbxuser

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/NYPLUtilities.xcodeproj/project.pbxproj
+++ b/NYPLUtilities.xcodeproj/project.pbxproj
@@ -1,0 +1,574 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7350A8D127694FD6003CCE46 /* NYPLUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */; };
+		73DE15952771304A0061D12F /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE158F2771304A0061D12F /* RSAUtils.swift */; };
+		73DE15962771304A0061D12F /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15912771304A0061D12F /* Data+Base64.swift */; };
+		73DE15972771304A0061D12F /* String+MD5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15922771304A0061D12F /* String+MD5.swift */; };
+		73DE15982771304A0061D12F /* NYPLOAuth2Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15942771304A0061D12F /* NYPLOAuth2Error.swift */; };
+		73DE159E277130750061D12F /* String+MD5Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE159B277130750061D12F /* String+MD5Tests.swift */; };
+		73DE159F277130750061D12F /* NYPLOAuth2ErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE159D277130750061D12F /* NYPLOAuth2ErrorTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		7350A8D227694FD6003CCE46 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7350A8BD27694FD6003CCE46 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7350A8C527694FD6003CCE46;
+			remoteInfo = NYPLUtilities;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYPLUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYPLUtilitiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		73DE158F2771304A0061D12F /* RSAUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAUtils.swift; sourceTree = "<group>"; };
+		73DE15912771304A0061D12F /* Data+Base64.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+Base64.swift"; sourceTree = "<group>"; };
+		73DE15922771304A0061D12F /* String+MD5.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+MD5.swift"; sourceTree = "<group>"; };
+		73DE15942771304A0061D12F /* NYPLOAuth2Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLOAuth2Error.swift; sourceTree = "<group>"; };
+		73DE159B277130750061D12F /* String+MD5Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+MD5Tests.swift"; sourceTree = "<group>"; };
+		73DE159D277130750061D12F /* NYPLOAuth2ErrorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLOAuth2ErrorTests.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7350A8C327694FD6003CCE46 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7350A8CD27694FD6003CCE46 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7350A8D127694FD6003CCE46 /* NYPLUtilities.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7350A8BC27694FD6003CCE46 = {
+			isa = PBXGroup;
+			children = (
+				73DE158D2771304A0061D12F /* Sources */,
+				7350A8EC276963D9003CCE46 /* Supporting Files */,
+				73DE1599277130750061D12F /* Tests */,
+				7350A8C727694FD6003CCE46 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7350A8C727694FD6003CCE46 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */,
+				7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7350A8EC276963D9003CCE46 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		73DE158D2771304A0061D12F /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				73DE158E2771304A0061D12F /* Crypto */,
+				73DE15902771304A0061D12F /* Strings */,
+				73DE15932771304A0061D12F /* Errors */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		73DE158E2771304A0061D12F /* Crypto */ = {
+			isa = PBXGroup;
+			children = (
+				73DE158F2771304A0061D12F /* RSAUtils.swift */,
+			);
+			path = Crypto;
+			sourceTree = "<group>";
+		};
+		73DE15902771304A0061D12F /* Strings */ = {
+			isa = PBXGroup;
+			children = (
+				73DE15912771304A0061D12F /* Data+Base64.swift */,
+				73DE15922771304A0061D12F /* String+MD5.swift */,
+			);
+			path = Strings;
+			sourceTree = "<group>";
+		};
+		73DE15932771304A0061D12F /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				73DE15942771304A0061D12F /* NYPLOAuth2Error.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
+		73DE1599277130750061D12F /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				73DE159A277130750061D12F /* Strings */,
+				73DE159C277130750061D12F /* Errors */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		73DE159A277130750061D12F /* Strings */ = {
+			isa = PBXGroup;
+			children = (
+				73DE159B277130750061D12F /* String+MD5Tests.swift */,
+			);
+			path = Strings;
+			sourceTree = "<group>";
+		};
+		73DE159C277130750061D12F /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				73DE159D277130750061D12F /* NYPLOAuth2ErrorTests.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		7350A8C127694FD6003CCE46 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		7350A8C527694FD6003CCE46 /* NYPLUtilities */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7350A8DA27694FD6003CCE46 /* Build configuration list for PBXNativeTarget "NYPLUtilities" */;
+			buildPhases = (
+				7350A8C127694FD6003CCE46 /* Headers */,
+				7350A8C227694FD6003CCE46 /* Sources */,
+				7350A8C327694FD6003CCE46 /* Frameworks */,
+				7350A8C427694FD6003CCE46 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NYPLUtilities;
+			productName = NYPLUtilities;
+			productReference = 7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		7350A8CF27694FD6003CCE46 /* NYPLUtilitiesTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7350A8DD27694FD6003CCE46 /* Build configuration list for PBXNativeTarget "NYPLUtilitiesTests" */;
+			buildPhases = (
+				7350A8CC27694FD6003CCE46 /* Sources */,
+				7350A8CD27694FD6003CCE46 /* Frameworks */,
+				7350A8CE27694FD6003CCE46 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7350A8D327694FD6003CCE46 /* PBXTargetDependency */,
+			);
+			name = NYPLUtilitiesTests;
+			productName = NYPLUtilitiesTests;
+			productReference = 7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7350A8BD27694FD6003CCE46 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1310;
+				LastUpgradeCheck = 1310;
+				TargetAttributes = {
+					7350A8C527694FD6003CCE46 = {
+						CreatedOnToolsVersion = 13.1;
+					};
+					7350A8CF27694FD6003CCE46 = {
+						CreatedOnToolsVersion = 13.1;
+					};
+				};
+			};
+			buildConfigurationList = 7350A8C027694FD6003CCE46 /* Build configuration list for PBXProject "NYPLUtilities" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7350A8BC27694FD6003CCE46;
+			productRefGroup = 7350A8C727694FD6003CCE46 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7350A8C527694FD6003CCE46 /* NYPLUtilities */,
+				7350A8CF27694FD6003CCE46 /* NYPLUtilitiesTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7350A8C427694FD6003CCE46 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7350A8CE27694FD6003CCE46 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7350A8C227694FD6003CCE46 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				73DE15982771304A0061D12F /* NYPLOAuth2Error.swift in Sources */,
+				73DE15952771304A0061D12F /* RSAUtils.swift in Sources */,
+				73DE15972771304A0061D12F /* String+MD5.swift in Sources */,
+				73DE15962771304A0061D12F /* Data+Base64.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7350A8CC27694FD6003CCE46 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				73DE159E277130750061D12F /* String+MD5Tests.swift in Sources */,
+				73DE159F277130750061D12F /* NYPLOAuth2ErrorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7350A8D327694FD6003CCE46 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7350A8C527694FD6003CCE46 /* NYPLUtilities */;
+			targetProxy = 7350A8D227694FD6003CCE46 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		7350A8D827694FD6003CCE46 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES;
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_FRAMEWORK_INCLUDE_PRIVATE_FROM_PUBLIC = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 NYPL Labs. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		7350A8D927694FD6003CCE46 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
+				CLANG_ANALYZER_GCD_PERFORMANCE = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES;
+				CLANG_WARN_ASSIGN_ENUM = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_COMPLETION_HANDLER_MISUSE = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_FRAMEWORK_INCLUDE_PRIVATE_FROM_PUBLIC = YES;
+				CLANG_WARN_IMPLICIT_SIGN_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_INITIALIZER_NOT_FULLY_BRACKETED = YES;
+				GCC_WARN_SHADOW = YES;
+				GCC_WARN_SIGN_COMPARE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2021 NYPL Labs. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		7350A8DB27694FD6003CCE46 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 7262U6ST2R;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.NYPLUtilities;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				RUN_CLANG_STATIC_ANALYZER = YES;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7350A8DC27694FD6003CCE46 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 7262U6ST2R;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.NYPLUtilities;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				RUN_CLANG_STATIC_ANALYZER = YES;
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		7350A8DE27694FD6003CCE46 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7262U6ST2R;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.NYPLUtilitiesTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7350A8DF27694FD6003CCE46 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7262U6ST2R;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.nypl.labs.NYPLUtilitiesTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7350A8C027694FD6003CCE46 /* Build configuration list for PBXProject "NYPLUtilities" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7350A8D827694FD6003CCE46 /* Debug */,
+				7350A8D927694FD6003CCE46 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7350A8DA27694FD6003CCE46 /* Build configuration list for PBXNativeTarget "NYPLUtilities" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7350A8DB27694FD6003CCE46 /* Debug */,
+				7350A8DC27694FD6003CCE46 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7350A8DD27694FD6003CCE46 /* Build configuration list for PBXNativeTarget "NYPLUtilitiesTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7350A8DE27694FD6003CCE46 /* Debug */,
+				7350A8DF27694FD6003CCE46 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7350A8BD27694FD6003CCE46 /* Project object */;
+}

--- a/NYPLUtilities.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/NYPLUtilities.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/NYPLUtilities.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/NYPLUtilities.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/NYPLUtilities.xcodeproj/xcshareddata/xcschemes/NYPLUtilities.xcscheme
+++ b/NYPLUtilities.xcodeproj/xcshareddata/xcschemes/NYPLUtilities.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7350A8C527694FD6003CCE46"
+               BuildableName = "NYPLUtilities.framework"
+               BlueprintName = "NYPLUtilities"
+               ReferencedContainer = "container:NYPLUtilities.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7350A8CF27694FD6003CCE46"
+               BuildableName = "NYPLUtilitiesTests.xctest"
+               BlueprintName = "NYPLUtilitiesTests"
+               ReferencedContainer = "container:NYPLUtilities.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7350A8C527694FD6003CCE46"
+            BuildableName = "NYPLUtilities.framework"
+            BlueprintName = "NYPLUtilities"
+            ReferencedContainer = "container:NYPLUtilities.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     products: [
         .library(
             name: "NYPLUtilities",
+            type: .dynamic,
             targets: ["NYPLUtilities"]),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NYPLUtilities",
+    platforms: [.iOS(.v10), .macOS(.v10_12)],
+    products: [
+        .library(
+            name: "NYPLUtilities",
+            targets: ["NYPLUtilities"]),
+    ],
+    targets: [
+        .target(
+            name: "NYPLUtilities",
+            dependencies: [],
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "NYPLUtilitiesTests",
+            dependencies: ["NYPLUtilities"],
+            path: "Tests"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Simplified iOS Utilities
+
+This is a collection of utilities used at NYPL in the [Simplified](https://github.com/NYPL-Simplified) suite of products and code bases for iOS.
+
+## Objectives
+
+- Generality: the classes and functions should be general-purpose enough to be used independently of the product they are used in.
+- Absolutely no third party dependencies: we want to be able to use this module anywhere without any additional requirements.
+- Testability: every utility should be easily unit-testable.
+
+## Requirements
+
+- Xcode 13
+- iOS 10+
+- Swift 5
+
+## License
+
+This code is available under the Apache License, Version 2.0. See the [LICENSE](LICENSE) file for more info.

--- a/Sources/Crypto/RSAUtils.swift
+++ b/Sources/Crypto/RSAUtils.swift
@@ -1,0 +1,17 @@
+import Foundation
+import CommonCrypto
+
+public class RSAUtils {
+  public class func SHA256HashedData(from data: NSData) -> NSData {
+    let outputLength = CC_SHA256_DIGEST_LENGTH
+    var output = [UInt8](repeating: 0, count: Int(outputLength))
+    CC_SHA256(data.bytes, CC_LONG(data.length), &output)
+    return NSData(bytes: output, length: Int(outputLength))
+  }
+  
+  public class func stripPEMKeyHeader(_ key: String) -> String {
+    let fullRange = NSRange(location: 0, length: key.lengthOfBytes(using: .utf8))
+    let regExp = try! NSRegularExpression(pattern: "(-----BEGIN.*?-----)|(-----END.*?-----)|\\s+", options: [])
+    return regExp.stringByReplacingMatches(in: key, options: [], range: fullRange, withTemplate: "")
+  }
+}

--- a/Sources/Errors/NYPLOAuth2Error.swift
+++ b/Sources/Errors/NYPLOAuth2Error.swift
@@ -1,0 +1,75 @@
+//
+//  NYPLOAuth2Error.swift
+//  OverdriveProcessor
+//
+//  Created by Ettore Pasquini on 11/16/21.
+//  Copyright © 2021 NYPL. All rights reserved.
+//
+
+import Foundation
+
+/// This enum maps all possible OAuth2 error codes.
+///
+/// Reference:  https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
+public enum NYPLOAuth2ErrorCode: String, Decodable {
+  case invalidRequest = "invalid_request"
+  case invalidClient = "invalid_client"
+  case invalidGrant = "invalid_grant"
+  case unauthorizedClient = "unauthorized_client"
+  case unsupportedGrantType = "unsupported_grant_type"
+  case invalidScope = "invalid_scope"
+
+  public var intValue: Int {
+    switch self {
+    case .invalidRequest: return 10000
+    case .invalidClient: return 10001
+    case .invalidGrant: return 10002
+    case .unauthorizedClient: return 10003
+    case .unsupportedGrantType: return 10004
+    case .invalidScope: return 10005
+    }
+  }
+}
+
+public struct NYPLOAuth2Error: Decodable {
+  public let errorCode: NYPLOAuth2ErrorCode
+  public let errorDescription: String?
+  public let errorUri: String?
+
+  private enum CodingKeys: String, CodingKey {
+    case errorCode = "error"
+    case errorDescription
+    case errorUri
+  }
+
+  public static func fromData(_ data: Data) throws -> NYPLOAuth2Error {
+    let jsonDecoder = JSONDecoder()
+    jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try jsonDecoder.decode(NYPLOAuth2Error.self, from: data)
+  }
+
+  public func nsError(forRequest req: URLRequest, response: HTTPURLResponse) -> NSError {
+    return NSError(domain: "OAuth2 Error",
+                   code: errorCode.intValue,
+                   userInfo: ["errorCodeString": errorCode.rawValue,
+                              "errorDescription": errorDescription ?? "",
+                              "errorUri": errorUri ?? "",
+                              "request": req.loggableString,
+                              "response": response.statusCode
+                             ])
+  }
+}
+
+public extension URLRequest {
+  /// Since a request can include sensitive data such as access tokens, etc,
+  /// this computed variable includes a "safe" set of data that we can log.
+  var loggableString: String {
+    let methodAndURL = "\(httpMethod ?? "") \(url?.absoluteString ?? "")"
+    let headers = allHTTPHeaderFields?.filter {
+      $0.key.lowercased() != "authorization"
+    } ?? [:]
+
+    return "\(methodAndURL)\n  headers: \(headers)"
+  }
+}
+

--- a/Sources/Strings/Data+Base64.swift
+++ b/Sources/Strings/Data+Base64.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension Data {
+  public func base64EncodedStringUrlSafe() -> String {
+    return self.base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "\n", with: "")
+  }
+}

--- a/Sources/Strings/String+MD5.swift
+++ b/Sources/Strings/String+MD5.swift
@@ -1,0 +1,26 @@
+// Adapted from: https://stackoverflow.com/a/31932898/9964065
+// TODO: Migrate to new Crypto API coming soon
+
+import Foundation
+import CommonCrypto
+
+extension String {
+  public func md5() -> Data {
+    let messageData = self.data(using:.utf8)!
+    var digestData = Data(count: Int(CC_MD5_DIGEST_LENGTH))
+    
+    _ = digestData.withUnsafeMutableBytes { digestBytes in
+      messageData.withUnsafeBytes { messageBytes in
+        CC_MD5(messageBytes.baseAddress,
+               CC_LONG(messageData.count),
+               digestBytes.bindMemory(to: UInt8.self).baseAddress)
+      }
+    }
+    
+    return digestData
+  }
+
+  public func md5hex() -> String {
+    return md5().map { String(format: "%02hhx", $0) }.joined()
+  }
+}

--- a/Tests/Errors/NYPLOAuth2ErrorTests.swift
+++ b/Tests/Errors/NYPLOAuth2ErrorTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import NYPLUtilities
+
+class NYPLOAuth2ErrorTests: XCTestCase {
+
+  func testOAuth2ErrorDecoding() throws {
+    let errorString = """
+      {"error":"invalid_grant","error_description":"Invalid resource owner password credential."}
+      """
+    let errorData = errorString.data(using: .utf8)!
+
+    guard let oauthError = try? NYPLOAuth2Error.fromData(errorData) else {
+      XCTFail("unable to parse valid error")
+      return
+    }
+
+    XCTAssertEqual(oauthError.errorCode, NYPLOAuth2ErrorCode.invalidGrant)
+    XCTAssertEqual(oauthError.errorDescription, "Invalid resource owner password credential.")
+  }
+}

--- a/Tests/Strings/String+MD5Tests.swift
+++ b/Tests/Strings/String+MD5Tests.swift
@@ -1,0 +1,16 @@
+//
+//  String+NYPLAdditionsTests.swift
+//  SimplyETests
+//
+//  Created by Ettore Pasquini on 4/8/20.
+//  Copyright © 2020 NYPL Labs. All rights reserved.
+//
+
+import XCTest
+@testable import NYPLUtilities
+
+class String_md5Tests: XCTestCase {
+  func testMD5() {
+    XCTAssertEqual("password".md5hex(), "5f4dcc3b5aa765d61d8327deb882cf99")
+  }
+}


### PR DESCRIPTION
This initial version takes just a couple classes from [Simplified-iOS](https://github.com/NYPL-Simplified/Simplified-iOS),   [audiobook-ios-overdrive](https://github.com/NYPL-Simplified/audiobook-ios-overdrive) and [NYPLAudiobookToolkit](https://github.com/NYPL-Simplified/NYPLAudiobookToolkit) so that we can verify everything works before adding more stuff to this module. The swift code has not been altered from what we had in the originating repos.

We are also adding support for Swift Package Manager and a regular Xcode project.