### PR TITLE
iOS-349 Add wrapper class for DispatchSourceTimer

### DIFF
--- a/NYPLUtilities.xcodeproj/project.pbxproj
+++ b/NYPLUtilities.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		17123D5227D2B95200088193 /* CwlDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17123D5127D2B95200088193 /* CwlDispatch.swift */; };
 		1756E0F327D97A9100549C2E /* NYPLRepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */; };
+		1756E0F627DA8AE700549C2E /* NYPLRepeatingTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */; };
 		7350A8D127694FD6003CCE46 /* NYPLUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */; };
 		73DE15952771304A0061D12F /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE158F2771304A0061D12F /* RSAUtils.swift */; };
 		73DE15962771304A0061D12F /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15912771304A0061D12F /* Data+Base64.swift */; };
@@ -31,6 +32,7 @@
 /* Begin PBXFileReference section */
 		17123D5127D2B95200088193 /* CwlDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CwlDispatch.swift; sourceTree = "<group>"; };
 		1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimer.swift; sourceTree = "<group>"; };
+		1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimerTests.swift; sourceTree = "<group>"; };
 		7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYPLUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYPLUtilitiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73DE158F2771304A0061D12F /* RSAUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAUtils.swift; sourceTree = "<group>"; };
@@ -65,6 +67,14 @@
 			children = (
 				17123D5127D2B95200088193 /* CwlDispatch.swift */,
 				1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */,
+			);
+			path = DispatchSource;
+			sourceTree = "<group>";
+		};
+		1756E0F427DA8AA800549C2E /* DispatchSource */ = {
+			isa = PBXGroup;
+			children = (
+				1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */,
 			);
 			path = DispatchSource;
 			sourceTree = "<group>";
@@ -134,6 +144,7 @@
 		73DE1599277130750061D12F /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				1756E0F427DA8AA800549C2E /* DispatchSource */,
 				73DE159A277130750061D12F /* Strings */,
 				73DE159C277130750061D12F /* Errors */,
 			);
@@ -279,6 +290,7 @@
 			files = (
 				73DE159E277130750061D12F /* String+MD5Tests.swift in Sources */,
 				73DE159F277130750061D12F /* NYPLOAuth2ErrorTests.swift in Sources */,
+				1756E0F627DA8AE700549C2E /* NYPLRepeatingTimerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NYPLUtilities.xcodeproj/project.pbxproj
+++ b/NYPLUtilities.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		17123D5227D2B95200088193 /* CwlDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17123D5127D2B95200088193 /* CwlDispatch.swift */; };
+		1756E0F327D97A9100549C2E /* NYPLRepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */; };
 		7350A8D127694FD6003CCE46 /* NYPLUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */; };
 		73DE15952771304A0061D12F /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE158F2771304A0061D12F /* RSAUtils.swift */; };
 		73DE15962771304A0061D12F /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15912771304A0061D12F /* Data+Base64.swift */; };
@@ -29,6 +30,7 @@
 
 /* Begin PBXFileReference section */
 		17123D5127D2B95200088193 /* CwlDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CwlDispatch.swift; sourceTree = "<group>"; };
+		1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimer.swift; sourceTree = "<group>"; };
 		7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYPLUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYPLUtilitiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73DE158F2771304A0061D12F /* RSAUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAUtils.swift; sourceTree = "<group>"; };
@@ -62,6 +64,7 @@
 			isa = PBXGroup;
 			children = (
 				17123D5127D2B95200088193 /* CwlDispatch.swift */,
+				1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */,
 			);
 			path = DispatchSource;
 			sourceTree = "<group>";
@@ -261,6 +264,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1756E0F327D97A9100549C2E /* NYPLRepeatingTimer.swift in Sources */,
 				73DE15982771304A0061D12F /* NYPLOAuth2Error.swift in Sources */,
 				73DE15952771304A0061D12F /* RSAUtils.swift in Sources */,
 				73DE15972771304A0061D12F /* String+MD5.swift in Sources */,

--- a/Sources/DispatchSource/NYPLRepeatingTimer.swift
+++ b/Sources/DispatchSource/NYPLRepeatingTimer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-private enum NYPLTimerState {
+enum NYPLTimerState {
   case resumed
   case suspended
 }
@@ -17,7 +17,7 @@ private enum NYPLTimerState {
 // releasing, resuming or suspending the timer in the incorrect state.
 class NYPLRepeatingTimer {
   
-  private var state: NYPLTimerState
+  private(set) var state: NYPLTimerState
   
   private var timer: DispatchSourceTimer
   

--- a/Sources/DispatchSource/NYPLRepeatingTimer.swift
+++ b/Sources/DispatchSource/NYPLRepeatingTimer.swift
@@ -1,0 +1,62 @@
+//
+//  NYPLRepeatingTimer.swift
+//  NYPLUtilities
+//
+//  Created by Ernest Fan on 2022-03-09.
+//
+
+import Foundation
+
+private enum NYPLTimerState {
+  case resumed
+  case suspended
+}
+
+// This is a wrapper class of DispatchSourceTimer.
+// It keeps track of the state of the timer to avoid crash from
+// releasing, resuming or suspending the timer in the incorrect state.
+class NYPLRepeatingTimer {
+  
+  private var state: NYPLTimerState
+  
+  private var timer: DispatchSourceTimer
+  
+  init(interval: DispatchTimeInterval,
+       leeway: DispatchTimeInterval = .nanoseconds(0),
+       queue: DispatchQueue = DispatchQueue.global(),
+       handler: @escaping () -> Void) {
+    timer = DispatchSource.repeatingTimer(interval: interval, leeway: leeway, queue: queue, handler: handler)
+    state = .resumed
+  }
+  
+  deinit {
+    // Make sure timer is in the right state,
+    // releasing a suspended timer will cause a crash
+    // ref: https://developer.apple.com/forums/thread/15902?answerId=669654022#669654022
+    if state == .suspended {
+      timer.resume()
+    }
+  }
+  
+  func resume() {
+    // Make sure timer is in the right state,
+    // calling resume or suspend twice in a row will cause a crash
+    // ref: https://developer.apple.com/forums/thread/15902?answerId=669654022#669654022
+    guard state == .suspended else {
+      return
+    }
+    state = .resumed
+    timer.resume()
+  }
+  
+  func suspend() {
+    // Make sure timer is in the right state,
+    // calling resume or suspend twice in a row will cause a crash
+    // ref: https://developer.apple.com/forums/thread/15902?answerId=669654022#669654022
+    guard state == .resumed else {
+      return
+    }
+    state = .suspended
+    timer.suspend()
+  }
+}

--- a/Tests/DispatchSource/NYPLRepeatingTimerTests.swift
+++ b/Tests/DispatchSource/NYPLRepeatingTimerTests.swift
@@ -1,0 +1,41 @@
+//
+//  NYPLRepeatingTimerTests.swift
+//  NYPLUtilitiesTests
+//
+//  Created by Ernest Fan on 2022-03-10.
+//
+
+import XCTest
+@testable import NYPLUtilities
+
+class NYPLRepeatingTimerTests: XCTestCase {
+
+  var timer: NYPLRepeatingTimer!
+  
+  override func setUp() {
+    timer = NYPLRepeatingTimer(interval: .seconds(1), handler: {})
+  }
+
+  override func tearDown() {
+    timer = nil
+  }
+
+  func testTimerResumeMultipleCall() throws {
+    timer.resume()
+    timer.resume()
+    timer.resume()
+    timer.resume()
+    
+    XCTAssert(true)
+  }
+  
+  func testTimerSuspendMultipleCall() throws {
+    timer.suspend()
+    timer.suspend()
+    timer.suspend()
+    timer.suspend()
+    
+    XCTAssert(true)
+  }
+
+}

--- a/Tests/DispatchSource/NYPLRepeatingTimerTests.swift
+++ b/Tests/DispatchSource/NYPLRepeatingTimerTests.swift
@@ -19,6 +19,18 @@ class NYPLRepeatingTimerTests: XCTestCase {
   override func tearDown() {
     timer = nil
   }
+  
+  func testTimerResumeAndSuspend() throws {
+    XCTAssertEqual(timer.state, .resumed)
+    
+    timer.suspend()
+    
+    XCTAssertEqual(timer.state, .suspended)
+    
+    timer.resume()
+    
+    XCTAssertEqual(timer.state, .resumed)
+  }
 
   func testTimerResumeMultipleCall() throws {
     timer.resume()
@@ -26,7 +38,7 @@ class NYPLRepeatingTimerTests: XCTestCase {
     timer.resume()
     timer.resume()
     
-    XCTAssert(true)
+    XCTAssertEqual(timer.state, .resumed)
   }
   
   func testTimerSuspendMultipleCall() throws {
@@ -35,7 +47,7 @@ class NYPLRepeatingTimerTests: XCTestCase {
     timer.suspend()
     timer.suspend()
     
-    XCTAssert(true)
+    XCTAssertEqual(timer.state, .suspended)
   }
 
 }


### PR DESCRIPTION
Implement a wrapper class of DispatchSourceTimer,
it keeps track of the state of the timer to avoid crash from releasing, resuming or suspending the timer in the incorrect state.