### PR TITLE
OE-216 Move access token class from CardCreator repo, add unit tests

### DIFF
--- a/Sources/Authentication/NYPLOAuthAccessToken.swift
+++ b/Sources/Authentication/NYPLOAuthAccessToken.swift
@@ -1,0 +1,30 @@
+//
+//  NYPLOAuthAccessToken.swift
+//  Created by Ettore Pasquini on 5/19/20.
+//  Copyright © 2020 NYPL. All rights reserved.
+//
+
+import Foundation
+
+public struct NYPLOAuthAccessToken: Decodable {
+  public let accessToken: String
+  public let expiresIn: TimeInterval? // Optional because non-essential
+
+  private let tokenTypeInternal: String?
+
+  /// Defaults to `Bearer` type in case an actual token type is missing.
+  public var tokenType: String {
+    return tokenTypeInternal ?? "Bearer"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case accessToken, expiresIn
+    case tokenTypeInternal = "tokenType"
+  }
+
+  public static func fromData(_ data: Data) -> NYPLOAuthAccessToken? {
+    let jsonDecoder = JSONDecoder()
+    jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+    return try? jsonDecoder.decode(NYPLOAuthAccessToken.self, from: data)
+  }
+}

--- a/Tests/Authentication/NYPLOAuthAccessTokenTests.swift
+++ b/Tests/Authentication/NYPLOAuthAccessTokenTests.swift
@@ -1,0 +1,44 @@
+//
+//  iOS-Utilities
+//  Created by Ettore Pasquini on 3/25/22.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+
+import Foundation
+import XCTest
+@testable import NYPLUtilities
+
+class NYPLOAuthAccessTokenTests: XCTestCase {
+  let tokenJSON = """
+    {
+    "access_token": "cazzo.strunz",
+    "expires_in": 3600,
+    "token_type": "Bearer"
+    }
+    """
+
+  func testOAuthAccessTokenParsingNonLossyASCII() {
+    guard let data = tokenJSON.data(using: .nonLossyASCII) else {
+      XCTFail("Failed to parse valid token as nonLossyASCII")
+      return
+    }
+    let token = NYPLOAuthAccessToken.fromData(data)
+    XCTAssertNotNil(token)
+    XCTAssertEqual(token?.accessToken, "cazzo.strunz")
+    XCTAssertEqual(token?.expiresIn, 3600)
+    XCTAssertEqual(token?.tokenType, "Bearer")
+  }
+
+  func testOAuthAccessTokenParsingUTF8() {
+    guard let data = tokenJSON.data(using: .utf8) else {
+      XCTFail("Failed to parse valid token as utf8")
+      return
+    }
+    let token = NYPLOAuthAccessToken.fromData(data)
+    XCTAssertNotNil(token)
+    XCTAssertEqual(token?.accessToken, "cazzo.strunz")
+    XCTAssertEqual(token?.expiresIn, 3600)
+    XCTAssertEqual(token?.tokenType, "Bearer")
+  }
+}


### PR DESCRIPTION
no changes in code, except for making the class `public` and adding unit tests.