### PR TITLE
IOS-415 Make sha256 api available to objc code

### DIFF
--- a/Sources/Crypto/RSAUtils.swift
+++ b/Sources/Crypto/RSAUtils.swift
@@ -22,3 +22,9 @@ extension String {
     NYPLStringAdditions.sha256forString(self)
   }
 }
+
+extension NSString {
+  @objc public var sha256: String? {
+    NYPLStringAdditions.sha256forString(self as String)
+  }
+}

--- a/Tests/Crypto/SHA256Tests.swift
+++ b/Tests/Crypto/SHA256Tests.swift
@@ -37,4 +37,9 @@ class SHA256Tests: XCTestCase {
     XCTAssertEqual(spineKeyHash, cryptoKitHash)
     XCTAssertEqual(rsaUtilsHash, cryptoKitHash)
   }
+
+  func testSHA256() {
+    XCTAssertEqual("967824¬Ó¨⁄€™®©♟♞♝♜♛♚♙♘♗♖♕♔".sha256,
+                   "269b80eff0cd705e4b1de9fdbb2e1b0bccf30e6124cdc3487e8d74620eedf254")
+  }
 }


### PR DESCRIPTION
also move a unit test that was in simplified-iOS and  that instead belongs here.