### PR TITLE
IOS-437 Use symlink to latest Xcode on CI

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -5,8 +5,8 @@ jobs:
   build-and-test:
     runs-on: macOS-latest
     steps:
-      - name: Force Xcode 13.2
-        run: ls -la /Applications | grep  "Xcode" && sudo xcode-select -switch /Applications/Xcode_13.2.1.app
+      - name: Force latest Xcode #currently 13.2.1 cos 13.3.1 still in beta at github; once ready for prod the Xcode.app symlink will automatically select it
+        run: ls -la /Applications && sudo xcode-select -switch /Applications/Xcode.app
       - name: Print System Architecture
         run: uname -a && xcode-select -p
       - name: Checkout main repo and submodules

--- a/.swiftpm/xcode/xcshareddata/xcschemes/NYPLUtilities.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/NYPLUtilities.xcscheme
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NYPLUtilities"
+               BuildableName = "NYPLUtilities"
+               BlueprintName = "NYPLUtilities"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NYPLUtilitiesTests"
+               BuildableName = "NYPLUtilitiesTests"
+               BlueprintName = "NYPLUtilitiesTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NYPLUtilitiesObjc"
+               BuildableName = "NYPLUtilitiesObjc"
+               BlueprintName = "NYPLUtilitiesObjc"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NYPLUtilities"
+            BuildableName = "NYPLUtilities"
+            BlueprintName = "NYPLUtilities"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NYPLUtilitiesTests"
+               BuildableName = "NYPLUtilitiesTests"
+               BlueprintName = "NYPLUtilitiesTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NYPLUtilities"
+            BuildableName = "NYPLUtilities"
+            BlueprintName = "NYPLUtilities"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Usually we force a specific version, but currently the most up-to-date version on github is 13.2.1 while locally we are using 13.3.1. Using the symlink will automatically upgrade to a more recent version once it becomes ready for prod.