### PR TITLE
iOS-438 Update NYPLBookmarkSpec

### DIFF
--- a/NYPLUtilities.xcodeproj/project.pbxproj
+++ b/NYPLUtilities.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		17123D5227D2B95200088193 /* CwlDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17123D5127D2B95200088193 /* CwlDispatch.swift */; };
 		1756E0F327D97A9100549C2E /* NYPLRepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */; };
 		1756E0F627DA8AE700549C2E /* NYPLRepeatingTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */; };
+		177E04FD28A708C800DF7587 /* NYPLBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E04FC28A708C800DF7587 /* NYPLBookmark.swift */; };
 		7350A8D127694FD6003CCE46 /* NYPLUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */; };
 		73DE15952771304A0061D12F /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE158F2771304A0061D12F /* RSAUtils.swift */; };
 		73DE15962771304A0061D12F /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15912771304A0061D12F /* Data+Base64.swift */; };
@@ -33,6 +34,7 @@
 		17123D5127D2B95200088193 /* CwlDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CwlDispatch.swift; sourceTree = "<group>"; };
 		1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimer.swift; sourceTree = "<group>"; };
 		1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimerTests.swift; sourceTree = "<group>"; };
+		177E04FC28A708C800DF7587 /* NYPLBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookmark.swift; sourceTree = "<group>"; };
 		7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYPLUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYPLUtilitiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73DE158F2771304A0061D12F /* RSAUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAUtils.swift; sourceTree = "<group>"; };
@@ -79,6 +81,14 @@
 			path = DispatchSource;
 			sourceTree = "<group>";
 		};
+		177E04FB28A708B700DF7587 /* Bookmark */ = {
+			isa = PBXGroup;
+			children = (
+				177E04FC28A708C800DF7587 /* NYPLBookmark.swift */,
+			);
+			path = Bookmark;
+			sourceTree = "<group>";
+		};
 		7350A8BC27694FD6003CCE46 = {
 			isa = PBXGroup;
 			children = (
@@ -108,6 +118,7 @@
 		73DE158D2771304A0061D12F /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				177E04FB28A708B700DF7587 /* Bookmark */,
 				17123D5027D2B91200088193 /* DispatchSource */,
 				73DE158E2771304A0061D12F /* Crypto */,
 				73DE15902771304A0061D12F /* Strings */,
@@ -279,6 +290,7 @@
 				73DE15982771304A0061D12F /* NYPLOAuth2Error.swift in Sources */,
 				73DE15952771304A0061D12F /* RSAUtils.swift in Sources */,
 				73DE15972771304A0061D12F /* String+MD5.swift in Sources */,
+				177E04FD28A708C800DF7587 /* NYPLBookmark.swift in Sources */,
 				73DE15962771304A0061D12F /* Data+Base64.swift in Sources */,
 				17123D5227D2B95200088193 /* CwlDispatch.swift in Sources */,
 			);

--- a/NYPLUtilities.xcodeproj/project.pbxproj
+++ b/NYPLUtilities.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1756E0F327D97A9100549C2E /* NYPLRepeatingTimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */; };
 		1756E0F627DA8AE700549C2E /* NYPLRepeatingTimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */; };
 		177E04FD28A708C800DF7587 /* NYPLBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E04FC28A708C800DF7587 /* NYPLBookmark.swift */; };
+		177E050728AB283100DF7587 /* NYPLBookmarkSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E050628AB283100DF7587 /* NYPLBookmarkSpec.swift */; };
 		7350A8D127694FD6003CCE46 /* NYPLUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */; };
 		73DE15952771304A0061D12F /* RSAUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE158F2771304A0061D12F /* RSAUtils.swift */; };
 		73DE15962771304A0061D12F /* Data+Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DE15912771304A0061D12F /* Data+Base64.swift */; };
@@ -35,6 +36,7 @@
 		1756E0F227D97A9100549C2E /* NYPLRepeatingTimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimer.swift; sourceTree = "<group>"; };
 		1756E0F527DA8AE600549C2E /* NYPLRepeatingTimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLRepeatingTimerTests.swift; sourceTree = "<group>"; };
 		177E04FC28A708C800DF7587 /* NYPLBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NYPLBookmark.swift; sourceTree = "<group>"; };
+		177E050628AB283100DF7587 /* NYPLBookmarkSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NYPLBookmarkSpec.swift; sourceTree = "<group>"; };
 		7350A8C627694FD6003CCE46 /* NYPLUtilities.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYPLUtilities.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7350A8D027694FD6003CCE46 /* NYPLUtilitiesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NYPLUtilitiesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		73DE158F2771304A0061D12F /* RSAUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RSAUtils.swift; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 			isa = PBXGroup;
 			children = (
 				177E04FC28A708C800DF7587 /* NYPLBookmark.swift */,
+				177E050628AB283100DF7587 /* NYPLBookmarkSpec.swift */,
 			);
 			path = Bookmark;
 			sourceTree = "<group>";
@@ -291,6 +294,7 @@
 				73DE15952771304A0061D12F /* RSAUtils.swift in Sources */,
 				73DE15972771304A0061D12F /* String+MD5.swift in Sources */,
 				177E04FD28A708C800DF7587 /* NYPLBookmark.swift in Sources */,
+				177E050728AB283100DF7587 /* NYPLBookmarkSpec.swift in Sources */,
 				73DE15962771304A0061D12F /* Data+Base64.swift in Sources */,
 				17123D5227D2B95200088193 /* CwlDispatch.swift in Sources */,
 			);

--- a/Sources/Bookmark/NYPLBookmark.swift
+++ b/Sources/Bookmark/NYPLBookmark.swift
@@ -1,0 +1,17 @@
+//
+//  NYPLBookmark.swift
+//  NYPLUtilities
+//
+//  Created by Ernest Fan on 2022-08-12.
+//
+
+import Foundation
+
+public protocol NYPLBookmark {
+  var annotationId: String? { get set }
+  var device: String? { get }
+  var creationTime: Date { get }
+  
+  func serializableRepresentation(forMotivation motivation: NYPLBookmarkSpec.Motivation,
+                                  bookID: String) -> [String: Any]
+}

--- a/Sources/Bookmark/NYPLBookmarkSpec.swift
+++ b/Sources/Bookmark/NYPLBookmarkSpec.swift
@@ -1,0 +1,252 @@
+//
+//  NYPLBookmarkSpec.swift
+//  Simplified
+//
+//  Created by Ettore Pasquini on 3/24/21.
+//  Copyright © 2021 NYPL. All rights reserved.
+//
+
+/// A type representing the [format](https://git.io/JYEkT) of bookmark data
+/// shared between clients nd server in the Library Simplified ecosystem.
+///
+/// The structure of this type mimics the structure of the spec, as one
+/// can see from the [provided examples](https://git.io/JYYFZ).
+/// All required keys are listed. When a `value` property is present,
+/// it means it's a required fixed value. E.g. the `"type"` key *MUST*
+/// have a value equal to the `"Annotation"` literal. Fields that allow more
+/// more than one fixed value are expressed with enums (e.g. see `Motivation`.)
+///
+/// Bookmarks created inside the R2 reader *MUST* provide a value for all
+/// the keys listed here; exceptions are noted on each individual field.
+///
+/// Bookmarks created inside the R1 reader *MAY* comply to the same spec
+/// and historically some of the key/values overlap, although there has not
+/// been consistence in how those bookmarks are defined, especially
+/// cross-platform.
+///
+/// See the [full spec](https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec)
+/// for more details.
+struct NYPLBookmarkSpec {
+  struct Context {
+    /// The key identifying the `Context` section.
+    static let key = "@context"
+    /// The only possible value for the `Context` section key.
+    static let value = "http://www.w3.org/ns/anno.jsonld"
+  }
+
+  struct type {
+    /// The key identifying the `Type` section.
+    static let key = "type"
+    /// The only possible value for the `Type` section key.
+    static let value = "Annotation"
+  }
+
+  struct Id {
+    /// The key identifying the `Id` section.
+    static let key = "id"
+    /// The value of the annotation ID.
+    let value: String?
+  }
+
+  /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#bodies.
+  struct Body {
+    /// The key identifying the `Body` section.
+    static let key = "body"
+
+    struct Time {
+      static let key = "http://librarysimplified.org/terms/time"
+      /// The `Time` value is a timestamp string formatted per
+      /// [RFC 3339](https://tools.ietf.org/html/rfc3339).
+      /// The timestamp value itself must be in UTC time zone.
+      let value: String
+    }
+    let time: Time
+
+    struct Device {
+      static let key = "http://librarysimplified.org/terms/device"
+      /// Clients that do not have access to an actual DRM device identifier
+      /// _SHOULD_ use this value.
+      static let nullValue = "null"
+      /// The Device value is a DRM device identifier, such as what is
+      /// provided by `NYPLUserAccount::deviceID`.
+      let value: String
+    }
+    let device: Device
+
+    /// Extra metadata that the app can use for display to the user.
+    ///
+    /// For example, total book progress info.
+    let others: [String: String]?
+
+    init(time: String, device: String, others: [String: String]? = nil) {
+      self.time = Time(value: time)
+      self.device = Device(value: device)
+      self.others = others
+    }
+  }
+
+  /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#motivations
+  enum Motivation: String {
+    /// The key identifying the `Motivation` section.
+    static let key = "motivation"
+    /// The keyword identifying an explicit bookmark in a textual search.
+    static let bookmarkingKeyword = "bookmarking"
+    /// The motivation value for an explicit user bookmark.
+    case bookmark = "http://www.w3.org/ns/oa#bookmarking"
+    /// The motivation value for the implicit bookmark related to the last
+    /// read position.
+    case readingProgress = "http://librarysimplified.org/terms/annotation/idling"
+  }
+
+  /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#targets
+  struct Target {
+    static let key = "target"
+
+    struct Selector {
+      static let key = "selector"
+
+      /// The Selector `type` has always a fixed value.
+      struct type {
+        /// The key identifying the Selector type.
+        static let key = "type"
+        /// The only possible value for the Selector's `Type` key.
+        static let value = "oa:FragmentSelector"
+      }
+
+      /// The Selector `Value` contains a [locator](https://git.io/JYTyx)
+      /// serialized as a JSON string. This type defines the possible
+      /// locator's keys, as well as required values.
+      struct Value {
+        /// The key identifying the Selector `Value`.
+        static let key = "value"
+
+        /// The locator key identifying its type. This key will appear inside
+        /// the `selectorValue` String.
+        static let locatorTypeKey = "@type"
+        /// The only value for the `locatorTypeKey` field for all non-legacy
+        /// locators supported by this spec. This will appear inside
+        /// the `selectorValue` String.
+        static let locatorTypeValue = "LocatorHrefProgression"
+        /// The locator key identifying the chapter id of the bookmark.
+        /// This key will appear inside the `selectorValue` String.
+        static let locatorChapterIDKey = "href"
+        /// The locator key identifying the progression % inside the chapter.
+        /// This key will appear inside the `selectorValue` String.
+        static let locatorChapterProgressionKey = "progressWithinChapter"
+
+        /// Locators can be expressed in a legacy format using CFI to
+        /// identify the position in the book. In that case, the value for
+        /// `locatorTypeKey` is expressed by this constant.
+        static let legacyLocatorTypeValue = "LocatorLegacyCFI"
+        /// The locator key identifying the chapter id of the bookmark in the
+        /// legacy format. This key appear inside the legacy `selectorValue`
+        /// strings used in R1.
+        static let locatorLegacyChapterIDKey = "idref"
+        /// This is a key related to an optional Selector Value field,
+        /// provided for backward compatibility with R1 bookmarks.
+        static let legacyLocatorCFIKey = "contentCFI"
+
+        /// A serialized JSON string (its keys and values are escaped)
+        /// containing a [locator](https://git.io/JYTyx), e.g.
+        /// "{\"@type\": \"LocatorHrefProgression\", \"idref\": \"/xyz.html\",
+        ///   \"progressWithinChapter\": 0.5}"
+        let selectorValue: String
+      }
+      let value: Value
+    } //Selector
+    let selector: Selector
+
+    struct Source {
+      static let key = "source"
+      /// Typically the book ID from the OPDS feed.
+      let value: String
+    }
+    let source: Source
+
+    init(bookID: String, selectorValue: String) {
+      self.source = Source(value: bookID)
+      self.selector = Selector(value: Selector.Value(selectorValue: selectorValue))
+    }
+  }
+
+  let id: Id
+  let body: Body
+  let motivation: Motivation
+  let target: Target
+
+  init(id: String? = nil,
+       time: Date,
+       device: String,
+       bodyOthers: [String: String]? = nil,
+       motivation: Motivation,
+       bookID: String,
+       selectorValue: String) {
+    self.id = Id(value: id)
+    self.body = Body(time: time.rfc3339String, device: device, others: bodyOthers)
+    self.motivation = motivation
+    self.target = Target(bookID: bookID, selectorValue: selectorValue)
+  }
+}
+
+// MARK:- iOS-only Additions
+
+extension NYPLBookmarkSpec.Body {
+  struct BookProgress {
+    static let key = "http://librarysimplified.org/terms/progressWithinBook"
+
+    /// The `BookProgress` value is a % value ranged [0...1]
+    let value: Float?
+
+    var dictionaryValue: [String: String] {
+      guard let value = value else {
+        return [:]
+      }
+
+      return [
+        BookProgress.key: String(value)
+      ]
+    }
+  }
+}
+
+// MARK:- Utilities
+
+extension NYPLBookmarkSpec {
+  /// - returns: A dictionary that can be given to `JSONSerialization` as a
+  /// JSON object to be serialized into a binary Data blob.
+  func dictionaryForJSONSerialization() -> [String: Any] {
+    var newBody: [String: Any] = [
+      NYPLBookmarkSpec.Body.Time.key: body.time.value,
+      NYPLBookmarkSpec.Body.Device.key: body.device.value
+    ]
+    if let others = body.others {
+      newBody.merge(others, uniquingKeysWith: { (current, _) in current })
+    }
+
+    var dict: [String: Any] = [
+      NYPLBookmarkSpec.Context.key: NYPLBookmarkSpec.Context.value,
+      NYPLBookmarkSpec.type.key: NYPLBookmarkSpec.type.value,
+      NYPLBookmarkSpec.Body.key: newBody,
+      NYPLBookmarkSpec.Motivation.key: motivation.rawValue,
+      NYPLBookmarkSpec.Target.key: [
+        NYPLBookmarkSpec.Target.Source.key: target.source.value,
+        NYPLBookmarkSpec.Target.Selector.key: [
+          NYPLBookmarkSpec.Target.Selector.type.key: NYPLBookmarkSpec.Target.Selector.type.value,
+          NYPLBookmarkSpec.Target.Selector.Value.key: target.selector.value.selectorValue
+        ]
+      ]
+    ]
+
+    if let idValue = self.id.value {
+      dict[NYPLBookmarkSpec.Id.key] = idValue
+    }
+
+    return dict
+  }
+}
+
+// MARK:- R1 keys (legacy)
+
+enum NYPLBookmarkR1Key: String {
+  case idref
+}

--- a/Sources/Bookmark/NYPLBookmarkSpec.swift
+++ b/Sources/Bookmark/NYPLBookmarkSpec.swift
@@ -26,22 +26,24 @@
 ///
 /// See the [full spec](https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec)
 /// for more details.
-struct NYPLBookmarkSpec {
-  struct Context {
+import Foundation
+
+public struct NYPLBookmarkSpec {
+  public struct Context {
     /// The key identifying the `Context` section.
     static let key = "@context"
     /// The only possible value for the `Context` section key.
     static let value = "http://www.w3.org/ns/anno.jsonld"
   }
 
-  struct type {
+  public struct type {
     /// The key identifying the `Type` section.
     static let key = "type"
     /// The only possible value for the `Type` section key.
     static let value = "Annotation"
   }
 
-  struct Id {
+  public struct Id {
     /// The key identifying the `Id` section.
     static let key = "id"
     /// The value of the annotation ID.
@@ -49,11 +51,11 @@ struct NYPLBookmarkSpec {
   }
 
   /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#bodies.
-  struct Body {
+  public struct Body {
     /// The key identifying the `Body` section.
     static let key = "body"
 
-    struct Time {
+    public struct Time {
       static let key = "http://librarysimplified.org/terms/time"
       /// The `Time` value is a timestamp string formatted per
       /// [RFC 3339](https://tools.ietf.org/html/rfc3339).
@@ -62,7 +64,7 @@ struct NYPLBookmarkSpec {
     }
     let time: Time
 
-    struct Device {
+    public struct Device {
       static let key = "http://librarysimplified.org/terms/device"
       /// Clients that do not have access to an actual DRM device identifier
       /// _SHOULD_ use this value.
@@ -78,7 +80,7 @@ struct NYPLBookmarkSpec {
     /// For example, total book progress info.
     let others: [String: String]?
 
-    init(time: String, device: String, others: [String: String]? = nil) {
+    public init(time: String, device: String, others: [String: String]? = nil) {
       self.time = Time(value: time)
       self.device = Device(value: device)
       self.others = others
@@ -86,7 +88,7 @@ struct NYPLBookmarkSpec {
   }
 
   /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#motivations
-  enum Motivation: String {
+  public enum Motivation: String {
     /// The key identifying the `Motivation` section.
     static let key = "motivation"
     /// The keyword identifying an explicit bookmark in a textual search.
@@ -99,14 +101,14 @@ struct NYPLBookmarkSpec {
   }
 
   /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#targets
-  struct Target {
+  public struct Target {
     static let key = "target"
 
-    struct Selector {
+    public struct Selector {
       static let key = "selector"
 
       /// The Selector `type` has always a fixed value.
-      struct type {
+      public struct type {
         /// The key identifying the Selector type.
         static let key = "type"
         /// The only possible value for the Selector's `Type` key.
@@ -116,7 +118,7 @@ struct NYPLBookmarkSpec {
       /// The Selector `Value` contains a [locator](https://git.io/JYTyx)
       /// serialized as a JSON string. This type defines the possible
       /// locator's keys, as well as required values.
-      struct Value {
+      public struct Value {
         /// The key identifying the Selector `Value`.
         static let key = "value"
 
@@ -145,6 +147,29 @@ struct NYPLBookmarkSpec {
         /// This is a key related to an optional Selector Value field,
         /// provided for backward compatibility with R1 bookmarks.
         static let legacyLocatorCFIKey = "contentCFI"
+        
+        /// The value for the `locatorTypeKey` field for all audiobook
+        /// locators supported by this spec. This will appear inside
+        /// the `selectorValue` String.
+        static let audiobookLocatorTypeValue = "LocatorAudioBookTime"
+        /// The locator key identifying the part id of the bookmark.
+        /// This key will appear inside the `selectorValue` String.
+        static let audiobookLocatorPartKey = "part"
+        /// The locator key identifying the chapter id of the bookmark.
+        /// This key will appear inside the `selectorValue` String.
+        static let audiobookLocatorChapterKey = "chapter"
+        /// The locator key identifying the title of the chapter.
+        /// This key will appear inside the `selectorValue` String.
+        static let audiobookLocatorTitleKey = "title"
+        /// The locator key identifying the id of the audiobook.
+        /// This key will appear inside the `selectorValue` String.
+        static let audiobookLocatorBookIDKey = "audiobookID"
+        /// The locator key identifying the duration of the chapter.
+        /// This key will appear inside the `selectorValue` String.
+        static let audiobookLocatorDurationKey = "duration"
+        /// The locator key identifying the time offset of the bookmark.
+        /// This key will appear inside the `selectorValue` String.
+        static let audiobookLocatorOffsetKey = "time"
 
         /// A serialized JSON string (its keys and values are escaped)
         /// containing a [locator](https://git.io/JYTyx), e.g.
@@ -156,14 +181,14 @@ struct NYPLBookmarkSpec {
     } //Selector
     let selector: Selector
 
-    struct Source {
+    public struct Source {
       static let key = "source"
       /// Typically the book ID from the OPDS feed.
       let value: String
     }
     let source: Source
 
-    init(bookID: String, selectorValue: String) {
+    public init(bookID: String, selectorValue: String) {
       self.source = Source(value: bookID)
       self.selector = Selector(value: Selector.Value(selectorValue: selectorValue))
     }
@@ -174,13 +199,13 @@ struct NYPLBookmarkSpec {
   let motivation: Motivation
   let target: Target
 
-  init(id: String? = nil,
-       time: Date,
-       device: String,
-       bodyOthers: [String: String]? = nil,
-       motivation: Motivation,
-       bookID: String,
-       selectorValue: String) {
+  public init(id: String? = nil,
+              time: Date,
+              device: String,
+              bodyOthers: [String: String]? = nil,
+              motivation: Motivation,
+              bookID: String,
+              selectorValue: String) {
     self.id = Id(value: id)
     self.body = Body(time: time.rfc3339String, device: device, others: bodyOthers)
     self.motivation = motivation
@@ -190,8 +215,8 @@ struct NYPLBookmarkSpec {
 
 // MARK:- iOS-only Additions
 
-extension NYPLBookmarkSpec.Body {
-  struct BookProgress {
+public extension NYPLBookmarkSpec.Body {
+  public struct BookProgress {
     static let key = "http://librarysimplified.org/terms/progressWithinBook"
 
     /// The `BookProgress` value is a % value ranged [0...1]
@@ -211,10 +236,10 @@ extension NYPLBookmarkSpec.Body {
 
 // MARK:- Utilities
 
-extension NYPLBookmarkSpec {
+public extension NYPLBookmarkSpec {
   /// - returns: A dictionary that can be given to `JSONSerialization` as a
   /// JSON object to be serialized into a binary Data blob.
-  func dictionaryForJSONSerialization() -> [String: Any] {
+  public func dictionaryForJSONSerialization() -> [String: Any] {
     var newBody: [String: Any] = [
       NYPLBookmarkSpec.Body.Time.key: body.time.value,
       NYPLBookmarkSpec.Body.Device.key: body.device.value
@@ -247,6 +272,6 @@ extension NYPLBookmarkSpec {
 
 // MARK:- R1 keys (legacy)
 
-enum NYPLBookmarkR1Key: String {
+public enum NYPLBookmarkR1Key: String {
   case idref
 }

--- a/Sources/Bookmark/NYPLBookmarkSpec.swift
+++ b/Sources/Bookmark/NYPLBookmarkSpec.swift
@@ -31,54 +31,54 @@ import Foundation
 public struct NYPLBookmarkSpec {
   public struct Context {
     /// The key identifying the `Context` section.
-    static let key = "@context"
+    static public let key = "@context"
     /// The only possible value for the `Context` section key.
-    static let value = "http://www.w3.org/ns/anno.jsonld"
+    static public let value = "http://www.w3.org/ns/anno.jsonld"
   }
 
   public struct type {
     /// The key identifying the `Type` section.
-    static let key = "type"
+    static public let key = "type"
     /// The only possible value for the `Type` section key.
-    static let value = "Annotation"
+    static public let value = "Annotation"
   }
 
   public struct Id {
     /// The key identifying the `Id` section.
-    static let key = "id"
+    static public let key = "id"
     /// The value of the annotation ID.
-    let value: String?
+    public let value: String?
   }
 
   /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#bodies.
   public struct Body {
     /// The key identifying the `Body` section.
-    static let key = "body"
+    static public let key = "body"
 
     public struct Time {
-      static let key = "http://librarysimplified.org/terms/time"
+      static public let key = "http://librarysimplified.org/terms/time"
       /// The `Time` value is a timestamp string formatted per
       /// [RFC 3339](https://tools.ietf.org/html/rfc3339).
       /// The timestamp value itself must be in UTC time zone.
-      let value: String
+      public let value: String
     }
-    let time: Time
+    public let time: Time
 
     public struct Device {
-      static let key = "http://librarysimplified.org/terms/device"
+      static public let key = "http://librarysimplified.org/terms/device"
       /// Clients that do not have access to an actual DRM device identifier
       /// _SHOULD_ use this value.
-      static let nullValue = "null"
+      static public let nullValue = "null"
       /// The Device value is a DRM device identifier, such as what is
       /// provided by `NYPLUserAccount::deviceID`.
-      let value: String
+      public let value: String
     }
-    let device: Device
+    public let device: Device
 
     /// Extra metadata that the app can use for display to the user.
     ///
     /// For example, total book progress info.
-    let others: [String: String]?
+    public let others: [String: String]?
 
     public init(time: String, device: String, others: [String: String]? = nil) {
       self.time = Time(value: time)
@@ -90,9 +90,9 @@ public struct NYPLBookmarkSpec {
   /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#motivations
   public enum Motivation: String {
     /// The key identifying the `Motivation` section.
-    static let key = "motivation"
+    static public let key = "motivation"
     /// The keyword identifying an explicit bookmark in a textual search.
-    static let bookmarkingKeyword = "bookmarking"
+    static public let bookmarkingKeyword = "bookmarking"
     /// The motivation value for an explicit user bookmark.
     case bookmark = "http://www.w3.org/ns/oa#bookmarking"
     /// The motivation value for the implicit bookmark related to the last
@@ -102,17 +102,17 @@ public struct NYPLBookmarkSpec {
 
   /// See https://github.com/NYPL-Simplified/Simplified-Bookmarks-Spec#targets
   public struct Target {
-    static let key = "target"
+    static public let key = "target"
 
     public struct Selector {
-      static let key = "selector"
+      static public let key = "selector"
 
       /// The Selector `type` has always a fixed value.
       public struct type {
         /// The key identifying the Selector type.
-        static let key = "type"
+        static public let key = "type"
         /// The only possible value for the Selector's `Type` key.
-        static let value = "oa:FragmentSelector"
+        static public let value = "oa:FragmentSelector"
       }
 
       /// The Selector `Value` contains a [locator](https://git.io/JYTyx)
@@ -120,73 +120,73 @@ public struct NYPLBookmarkSpec {
       /// locator's keys, as well as required values.
       public struct Value {
         /// The key identifying the Selector `Value`.
-        static let key = "value"
+        static public let key = "value"
 
         /// The locator key identifying its type. This key will appear inside
         /// the `selectorValue` String.
-        static let locatorTypeKey = "@type"
+        static public let locatorTypeKey = "@type"
         /// The only value for the `locatorTypeKey` field for all non-legacy
         /// locators supported by this spec. This will appear inside
         /// the `selectorValue` String.
-        static let locatorTypeValue = "LocatorHrefProgression"
+        static public let locatorTypeValue = "LocatorHrefProgression"
         /// The locator key identifying the chapter id of the bookmark.
         /// This key will appear inside the `selectorValue` String.
-        static let locatorChapterIDKey = "href"
+        static public let locatorChapterIDKey = "href"
         /// The locator key identifying the progression % inside the chapter.
         /// This key will appear inside the `selectorValue` String.
-        static let locatorChapterProgressionKey = "progressWithinChapter"
+        static public let locatorChapterProgressionKey = "progressWithinChapter"
 
         /// Locators can be expressed in a legacy format using CFI to
         /// identify the position in the book. In that case, the value for
         /// `locatorTypeKey` is expressed by this constant.
-        static let legacyLocatorTypeValue = "LocatorLegacyCFI"
+        static public let legacyLocatorTypeValue = "LocatorLegacyCFI"
         /// The locator key identifying the chapter id of the bookmark in the
         /// legacy format. This key appear inside the legacy `selectorValue`
         /// strings used in R1.
-        static let locatorLegacyChapterIDKey = "idref"
+        static public let locatorLegacyChapterIDKey = "idref"
         /// This is a key related to an optional Selector Value field,
         /// provided for backward compatibility with R1 bookmarks.
-        static let legacyLocatorCFIKey = "contentCFI"
+        static public let legacyLocatorCFIKey = "contentCFI"
         
         /// The value for the `locatorTypeKey` field for all audiobook
         /// locators supported by this spec. This will appear inside
         /// the `selectorValue` String.
-        static let audiobookLocatorTypeValue = "LocatorAudioBookTime"
+        static public let audiobookLocatorTypeValue = "LocatorAudioBookTime"
         /// The locator key identifying the part id of the bookmark.
         /// This key will appear inside the `selectorValue` String.
-        static let audiobookLocatorPartKey = "part"
+        static public let audiobookLocatorPartKey = "part"
         /// The locator key identifying the chapter id of the bookmark.
         /// This key will appear inside the `selectorValue` String.
-        static let audiobookLocatorChapterKey = "chapter"
+        static public let audiobookLocatorChapterKey = "chapter"
         /// The locator key identifying the title of the chapter.
         /// This key will appear inside the `selectorValue` String.
-        static let audiobookLocatorTitleKey = "title"
+        static public let audiobookLocatorTitleKey = "title"
         /// The locator key identifying the id of the audiobook.
         /// This key will appear inside the `selectorValue` String.
-        static let audiobookLocatorBookIDKey = "audiobookID"
+        static public let audiobookLocatorBookIDKey = "audiobookID"
         /// The locator key identifying the duration of the chapter.
         /// This key will appear inside the `selectorValue` String.
-        static let audiobookLocatorDurationKey = "duration"
+        static public let audiobookLocatorDurationKey = "duration"
         /// The locator key identifying the time offset of the bookmark.
         /// This key will appear inside the `selectorValue` String.
-        static let audiobookLocatorOffsetKey = "time"
+        static public let audiobookLocatorOffsetKey = "time"
 
         /// A serialized JSON string (its keys and values are escaped)
         /// containing a [locator](https://git.io/JYTyx), e.g.
         /// "{\"@type\": \"LocatorHrefProgression\", \"idref\": \"/xyz.html\",
         ///   \"progressWithinChapter\": 0.5}"
-        let selectorValue: String
+        public let selectorValue: String
       }
-      let value: Value
+      public let value: Value
     } //Selector
-    let selector: Selector
+    public let selector: Selector
 
     public struct Source {
-      static let key = "source"
+      static public let key = "source"
       /// Typically the book ID from the OPDS feed.
-      let value: String
+      public let value: String
     }
-    let source: Source
+    public let source: Source
 
     public init(bookID: String, selectorValue: String) {
       self.source = Source(value: bookID)
@@ -194,10 +194,10 @@ public struct NYPLBookmarkSpec {
     }
   }
 
-  let id: Id
-  let body: Body
-  let motivation: Motivation
-  let target: Target
+  public let id: Id
+  public let body: Body
+  public let motivation: Motivation
+  public let target: Target
 
   public init(id: String? = nil,
               time: Date,
@@ -216,13 +216,13 @@ public struct NYPLBookmarkSpec {
 // MARK:- iOS-only Additions
 
 public extension NYPLBookmarkSpec.Body {
-  public struct BookProgress {
-    static let key = "http://librarysimplified.org/terms/progressWithinBook"
+  struct BookProgress {
+    static public let key = "http://librarysimplified.org/terms/progressWithinBook"
 
     /// The `BookProgress` value is a % value ranged [0...1]
-    let value: Float?
+    public let value: Float?
 
-    var dictionaryValue: [String: String] {
+    public var dictionaryValue: [String: String] {
       guard let value = value else {
         return [:]
       }
@@ -230,6 +230,10 @@ public extension NYPLBookmarkSpec.Body {
       return [
         BookProgress.key: String(value)
       ]
+    }
+    
+    public init(value: Float?) {
+      self.value = value
     }
   }
 }
@@ -239,7 +243,7 @@ public extension NYPLBookmarkSpec.Body {
 public extension NYPLBookmarkSpec {
   /// - returns: A dictionary that can be given to `JSONSerialization` as a
   /// JSON object to be serialized into a binary Data blob.
-  public func dictionaryForJSONSerialization() -> [String: Any] {
+  func dictionaryForJSONSerialization() -> [String: Any] {
     var newBody: [String: Any] = [
       NYPLBookmarkSpec.Body.Time.key: body.time.value,
       NYPLBookmarkSpec.Body.Device.key: body.device.value

--- a/Sources/Date/Date+NYPLAdditions.swift
+++ b/Sources/Date/Date+NYPLAdditions.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A date formatter to get date strings formatted per RFC 3339
+/// without incurring in the high cost of creating a new DateFormatter
+/// each time, which would be ~300% more expensive.
+fileprivate let rfc3339DateFormatter: DateFormatter = {
+  let df = DateFormatter()
+  df.locale = Locale(identifier: "en_US_POSIX")
+  df.timeZone = TimeZone(secondsFromGMT: 0)
+  return df
+}()
+
+public extension Date {
+  var rfc3339String: String {
+    rfc3339DateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"
+    return rfc3339DateFormatter.string(from: self)
+  }
+}
+
+@objc public extension NSDate {
+  @objc convenience init?(rfc3339String: String?) {
+    guard let rfc3339String = rfc3339String,
+          !rfc3339String.isEmpty else {
+      return nil
+    }
+    
+    rfc3339DateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ssX5"
+    if let date = rfc3339DateFormatter.date(from: rfc3339String) {
+      self.init(timeIntervalSince1970: date.timeIntervalSince1970)
+      return
+    }
+    
+    // Attempt to parse RFC3339 string with fractional seconds
+    rfc3339DateFormatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.SSSSSSX5"
+    if let date = rfc3339DateFormatter.date(from: rfc3339String) {
+      self.init(timeIntervalSince1970: date.timeIntervalSince1970)
+      return
+    }
+
+    return nil
+  }
+  
+  @objc var rfc3339String: String {
+    return (self as Date).rfc3339String
+  }
+}

--- a/Tests/Date/Date+NYPLAdditionsTests.swift
+++ b/Tests/Date/Date+NYPLAdditionsTests.swift
@@ -1,0 +1,68 @@
+//
+//  iOS-Utilities
+//  Created by Ernest Fan on 2022-08-23.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import XCTest
+@testable import NYPLUtilities
+
+class Date_NYPLAdditionsTests: XCTestCase {
+  let calendar: Calendar = {
+    var calendar = Calendar.current
+    calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+    calendar.locale = Locale(identifier: "en_US_POSIX")
+    return calendar
+  }()
+  
+  func testInvalidRFC3339Date() {
+    XCTAssertNil(NSDate(rfc3339String:"not a date"))
+    XCTAssertNil(NSDate(rfc3339String:""))
+  }
+
+  func testParsesRFC3339DateCorrectly() {
+    let date = NSDate(rfc3339String: "1984-09-08T08:23:45Z")
+
+    guard let date = date else {
+      XCTFail()
+      return
+    }
+    
+    let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date as Date)
+    XCTAssertNotNil(dateComponents)
+    XCTAssertEqual(dateComponents.year, 1984);
+    XCTAssertEqual(dateComponents.month, 9);
+    XCTAssertEqual(dateComponents.day, 8);
+    XCTAssertEqual(dateComponents.hour, 8);
+    XCTAssertEqual(dateComponents.minute, 23);
+    XCTAssertEqual(dateComponents.second, 45);
+  }
+
+  func testParsesRFC3339DateWithFractionalSecondsCorrectly() {
+    let date = NSDate(rfc3339String:"1984-09-08T08:23:45.99Z")
+    
+    guard let date = date else {
+      XCTFail()
+      return
+    }
+
+    let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date as Date)
+    XCTAssertNotNil(dateComponents)
+    XCTAssertEqual(dateComponents.year, 1984);
+    XCTAssertEqual(dateComponents.month, 9);
+    XCTAssertEqual(dateComponents.day, 8);
+    XCTAssertEqual(dateComponents.hour, 8);
+    XCTAssertEqual(dateComponents.minute, 23);
+    XCTAssertEqual(dateComponents.second, 45);
+  }
+
+  func testRFC3339RoundTrip() {
+    let date = NSDate(rfc3339String:"1984-09-08T10:23:45+0200")
+    XCTAssertNotNil(date)
+
+    let dateString = date?.rfc3339String
+    XCTAssertNotNil(dateString)
+
+    XCTAssertEqual(dateString, "1984-09-08T08:23:45Z")
+  }
+}


### PR DESCRIPTION
**What's this do?**
Update NYPLBookmarkSpec to support audiobook
Migrate NYPLBookmarkSpec to iOS-Utilities repo
Make NYPLBookmarkSpec public
Add NYPLBookmark protocol

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-438](https://jira.nypl.org/browse/IOS-438)

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 
